### PR TITLE
Add `license` field and rename `thumbnail` to `covers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Relative path to file with additional documentation in markdown.
 A list of tags.
 
 ### `covers`
-A list of cover images provided by either a relative path to the model folder, or a hyperlink starts with `https`. 
+A list of cover images provided by either a relative path to the model folder, or a hyperlink starts with `https`.
+
+Please use an image smaller than 500KB, aspect ratio width to height 2:1. The supported image formats are: `jpg`, `png`, `gif`.
 
 ### `format_version`
 Version of this bioimage.io configuration specification.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Programming language of the model definition. For now, we support `python` and `
 What about `javascript`?
 -->
 
-###  framework
+###  `framework`
 
 The deep learning framework for which this object has been implemented. For now, we support `pytorch` and `tensorflow`.
 Can be `null` if the implementation is not framework specific.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Relative path to file with additional documentation in markdown.
 ### `tags`
 A list of tags.
 
+### `covers`
+A list of cover images provided by either a relative path to the model folder, or a hyperlink starts with `https`. 
+
 ### `format_version`
 Version of this bioimage.io configuration specification.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ A string containing a brief description.
 A citation entry or list of citation entries.
 Each entry contains of a mandatory `text` field and either one or both of `doi` and `url`.
 
+### `license`
+A string to a common license name (e.g. `MIT`, `APLv2`) or a relative path to the license file.
+
 ### `authors`
 A list of author strings. 
 A string can be seperated by `;` in order to identify multiple handles per author.
@@ -134,8 +137,7 @@ For example:
 ## Model Specification
 
 A model entry in the bioimage.io model zoo is defined by a configuration file `<model name>.model.yaml`.
-The configuration file must contain the [common keys](#common-keys) and the keys `test_input`, test_output, `inputs`, `outputs,` `prediction`, `training`.
-It may contain the key `thumbnail`. Note that only the model specification contains test data, for all other implementations, we assume that the underlying components are sufficiently tested and we just perform one integration test for running the model.
+The configuration file must contain the [common keys](#common-keys) and the keys `test_input`, test_output, `inputs`, `outputs,` `prediction`, `training`. Note that only the model specification contains test data, for all other implementations, we assume that the underlying components are sufficiently tested and we just perform one integration test for running the model.
 
 ### `test_input`
 Relative file path to test input. `language` and the file extension define its memory representation.
@@ -144,9 +146,6 @@ The input is always stored as list of tensors.
 ### `test_output`
 Relative file path to test output. `language` and the file extension define its memory representation.
 The input is always stored as list of tensors.
-
-### `thumbnail`
-Image that will be displayed on the Model Zoo website to represent this Model.
 
 ### `inputs`
 Describes the input tensors expected by this model.

--- a/models/UNet2dExample.model.yaml
+++ b/models/UNet2dExample.model.yaml
@@ -8,11 +8,13 @@ description: A 2d U-Net pretrained on broad nucleus dataset.
 cite:
     - text: "Ronneberger, Olaf et al. U-net: Convolutional networks for biomedical image segmentation. MICCAI 2015."
       doi: https://doi.org/10.1007/978-3-319-24574-4_28
+license: MIT
 authors:
     - Constantin Pape;@constantinpape
     - Fynn Beutenmueller
 documentation: ./unet2d.md
 tags: [unet2d, pytorch, nucleus-segmentation]
+covers: []
 
 format_version: 0.1.0
 language: python
@@ -25,8 +27,6 @@ test_input: ./my_test_input.npy  # language + extension defines memory represent
 test_output: ./my_test_output.npy
 
 # optional:
-thumbnail: ./my_thumbnail.png
-
 inputs: # needs to become ordered dict (same for output) or list of dicts should contain names to
     # discussion about NCHWD versus bxyzt this also has implications on the location of the origin and the
   - name: input1


### PR DESCRIPTION
This PR add license to the to the configuration and rename `thumbnail` to `covers`.

The point of changing `thumbnail` to `covers` is that we may need to display multiple images for the same model to better represent what the model does. You can imagine a gallery of example input/output images for the model. Therefore I would prefer `covers`or `thumbnails` than `thumbnail`. I am also thinking perhaps we can have both types, say a `thumbnail` image represent the model itself, and a `gallery` which contains a list of example input/images. Please comment below.
